### PR TITLE
fix: dockerfile에 timezone 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY ${JAV_FILE} app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java","-jar","app.jar"]
+ENTRYPOINT ["java","-jar","-Duser.timezone=Asia/Seoul" ,"app.jar"]


### PR DESCRIPTION
# 개발사항

- Linux 타임존은 Seoul인데 Spring boot 시간은 다른 시간대인 이슈로 인해 JWT 만료됐다고 뜸.
- 둘의 시간 차이 9시간으로 인해, JWT 발급은 linux 시간으로, jwt 검증은 스프링시간으로 검사를 하는 것 같음.
- 두 시간을 맞춰주니 문제 해결

## 세부사항


Close #21 
